### PR TITLE
Removed exit command from renderPagePHANTOMJS()

### DIFF
--- a/http2pic.class.php
+++ b/http2pic.class.php
@@ -155,7 +155,6 @@ class http2pic
 		$cmd.= ','.$this->params['js'];
 		
 		$cmd = escapeshellcmd($cmd);
-		exit($cmd);
 		shell_exec($cmd);
 		$this->params['cmd'] = $cmd;
 		


### PR DESCRIPTION
Assume  this was a complete mistake and needed to be removed - phantomjs render would never work since the function would exit before running the phantomjs command.
