### PR TITLE
Change to PNG as default output

### DIFF
--- a/http2pic.class.php
+++ b/http2pic.class.php
@@ -63,7 +63,8 @@ class http2pic
 		switch($this->params['type'])
 		{
 			case 'png': $this->params['type'] = 'png'; break;
-			default: $this->params['type'] = 'jpg';
+			case 'jpg': $this->params['type'] = 'jpg'; break;			
+			default: $this->params['type'] = 'png';
 		}
 		
 		//validate timeout


### PR DESCRIPTION
I encountered a number of large web pages that would not render as jpg. Switching to png made them work. Suggest to make png the default now.
