### PR TITLE
Add Content-Disposition to make saving images cleaner

### DIFF
--- a/http2pic.class.php
+++ b/http2pic.class.php
@@ -231,13 +231,13 @@ class http2pic
 		if ($this->params['type'] === 'png') {
 			
 			header('Content-Type: image/png');
-			header('Content-Disposition: inline; filename="'.$this->trimToAlphaNumeric($this->params['url']).'"');
+			header('Content-Disposition: inline; filename="'.$this->trimToAlphaNumeric($this->params['url']).'.png"');
 			$result = imagecreatefrompng($this->params['file']);
 			imagepng($result, NULL, 9);
 		}
 		else {
 			header('Content-Type: image/jpeg');
-			header('Content-Disposition: inline; filename="'.$this->trimToAlphaNumeric($this->params['url']).'"');
+			header('Content-Disposition: inline; filename="'.$this->trimToAlphaNumeric($this->params['url']).'.jpg"');
 			$result = imagecreatefromjpeg($this->params['file']);
 			imagejpeg($result, NULL, 100);
 		}

--- a/http2pic.class.php
+++ b/http2pic.class.php
@@ -231,11 +231,13 @@ class http2pic
 		if ($this->params['type'] === 'png') {
 			
 			header('Content-Type: image/png');
+			header('Content-Disposition: inline; filename="'.$this->trimToAlphaNumeric($this->params['url']).'"');
 			$result = imagecreatefrompng($this->params['file']);
 			imagepng($result, NULL, 9);
 		}
 		else {
 			header('Content-Type: image/jpeg');
+			header('Content-Disposition: inline; filename="'.$this->trimToAlphaNumeric($this->params['url']).'"');
 			$result = imagecreatefromjpeg($this->params['file']);
 			imagejpeg($result, NULL, 100);
 		}


### PR DESCRIPTION
Thanks for making the tool, I use it every once and a while and I made a tweak on my instance that I think saves a little time/awkwardness.

When the API serves the image it now adds a Content-Disposition header which will set the filename to a trimmed version of the url. Currently if you try to save from api.php in a browser the save as dialog assumes api.php.png or api.png (obviously .png/.jpg depending on which image type). With this patch the filename in the header will be the trimmed version of the url + the extension.

Example with Chrome: 
Current: https://http2pic.haschek.at/api.php?url=http://google.com -> api.jpeg
Patch: https://http2pic.nerds.io/api.php?url=http://google.com&type=jpg -> httpgooglecom.jpg
